### PR TITLE
Fix leak in nft_queue when the queue is not empty in nft_shutdown

### DIFF
--- a/src/nft_queue.c
+++ b/src/nft_queue.c
@@ -373,6 +373,14 @@ nft_queue_dequeue(nft_queue * q, int timeout, void ** itemp)
 	// If the queue is less than one quarter full, shrink it by half.
 	if (!SHUTDOWN(q) && SHRINK(q)) queue_shrink(q);
 
+	// In nft_queue_shutdown, if there are any queued items, we will not release the
+	// initial reference that was held at queue creation time.  We only release it
+	// Once the queue is empty of items; this is that "extra" discard for that scenario.
+        if (EMPTY(q) && q->shutdown == 1 ) {
+	    q->shutdown++;
+	    nft_queue_discard(q);
+	}
+
 	return 0;
     }
     else if (SHUTDOWN(q))

--- a/src/nft_queue.c
+++ b/src/nft_queue.c
@@ -376,7 +376,7 @@ nft_queue_dequeue(nft_queue * q, int timeout, void ** itemp)
 	// In nft_queue_shutdown, if there are any queued items, we will not release the
 	// initial reference that was held at queue creation time.  We only release it
 	// Once the queue is empty of items; this is that "extra" discard for that scenario.
-        if (EMPTY(q) && q->shutdown == 1 ) {
+	if (EMPTY(q) && q->shutdown == 1 ) {
 	    q->shutdown++;
 	    nft_queue_discard(q);
 	}


### PR DESCRIPTION
This resolves issue #1 by ensuring that when we remove an item from the queue we also dereference the queue if it is in shutdown mode and an item is being removed.